### PR TITLE
fix(metric): nil pointer when error is not exist, but we still want to get it

### DIFF
--- a/metric/src/clients/http.go
+++ b/metric/src/clients/http.go
@@ -35,8 +35,10 @@ func (c *Http) handleError(err error) error {
 		return err
 	}
 
-	c.Enabled = false
-	c.logger.Error(err.Error())
+	if err != nil {
+		c.Enabled = false
+		c.logger.Error(err.Error())
+	}
 	return nil
 }
 


### PR DESCRIPTION
This will close #38